### PR TITLE
Fixes link to GH issue breaking on the gh-pages hosted version of the project

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,13 @@
           </div>
          </div>
       </form>
+
+        <div class="preview">
+          <h3>Preview</h3>
+          <div class="response"></div>
+          <div class="placeholder"></div>
+        </div
+
       <div class="api-example">
         <h3>Use</h3>
         <p class="js-help-json">To render the HTML data within an element, just use the value of <code>data.html</code> as the content (<a href="http://jsfiddle.net/TS8yS/">demo</a>).</p>
@@ -140,7 +147,10 @@
         <img src="http://api.twitter.com/1/users/profile_image/aaronlayton?size=normal" alt="Aaron Layton">
         <b>Aaron</b> Layton 
       </a>
-
+      <a href="http://twitter.com/addyosmani">
+        <img src="http://api.twitter.com/1/users/profile_image/addyosmani?size=normal" alt="Addy Osmani">
+        <b>Addy</b> Osmani
+      </a>
 </div>
     <p> <a href="https://github.com/h5bp/caniuse/contributors">&amp; more</a> </p>
     <p>This project was inspired by <a href="//get.webgl.org/">get.webgl.org</a> and was initiated over at <a href="http://github.com/paulirish/lazyweb-requests/issues/39">github.com/paulirish/lazyweb-requests#39</a>. Much thanks to <a href="//twitter.com/fyrd">Alexis Deveria</a> for the generous sharing of <a href="http://caniuse.com">caniuse</a> data. </p>

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
 
 </div>
     <p> <a href="https://github.com/h5bp/caniuse/contributors">&amp; more</a> </p>
-    <p>This project was inspired by <a href="//get.webgl.org/">get.webgl.org</a> and was initiated over at <a href="github.com/paulirish/lazyweb-requests/issues/39">github.com/paulirish/lazyweb-requests#39</a>. Much thanks to <a href="//twitter.com/fyrd">Alexis Deveria</a> for the generous sharing of <a href="http://caniuse.com">caniuse</a> data. </p>
+    <p>This project was inspired by <a href="//get.webgl.org/">get.webgl.org</a> and was initiated over at <a href="http://github.com/paulirish/lazyweb-requests/issues/39">github.com/paulirish/lazyweb-requests#39</a>. Much thanks to <a href="//twitter.com/fyrd">Alexis Deveria</a> for the generous sharing of <a href="http://caniuse.com">caniuse</a> data. </p>
     </footer>
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="site/js/jquery-1.7.1.min.js"><\/script>')</script>

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -392,6 +392,19 @@ label[for='features'] {
   .formats input[type="radio"]:focus + label {
     background: #5c5a72; }
 
+
+.preview {
+  display:none;
+}
+
+.preview .response{
+  white-space: pre; 
+  word-break: break-word; 
+  min-height:50px;
+  max-height:300px;
+  overflow-y:scroll;
+}
+
 .help {
   font-size: small;
   text-align: center;

--- a/site/css/style.scss
+++ b/site/css/style.scss
@@ -392,6 +392,18 @@ label[for='features'] {
   }
 }
 
+.preview {
+  display:none;
+}
+
+.preview .response{
+  white-space: pre; 
+  word-break: break-word; 
+  min-height:50px;
+  max-height:300px;
+  overflow-y:scroll;
+}
+
 .help {
   font-size: small;
   text-align: center;

--- a/site/js/script.js
+++ b/site/js/script.js
@@ -5,6 +5,7 @@
          $callbackvalue = $('#callbackvalue'),
          $callback = $('#callback'),
          $jsonhelp = $('.js-help-json'),
+         $preview = $('.preview'),
          originalCallbackValue = '',
          lastActive = false;
 
@@ -124,16 +125,35 @@
          if(api.features !== '') {
            api.options = formattedOptions();
           
-           $url.text(createUrl());
+           $createdUrl = createUrl();
+           $url.text($createdUrl);
            $url.attr('href', $url.text());
+           
 
            if(api.format == 'json') {
              $jsonhelp.show();
+              getPreview($createdUrl);
+              $preview.show();
            } else {
              $jsonhelp.hide();
+             $preview.hide();
            }
          }
       };
+
+
+      window.browserSupport = function(data) {   
+        if(api.format == 'json'){
+          $preview.find('.response').html("<h2>JSON</h2>" + JSON.stringify(data, null, '\t'));
+        }else{
+          //$preview.find('.response').html("<h2>HTML</h2>" + data.html);
+        }
+      }
+
+      function getPreview( url ){
+        $('.placeholder').html( $('<script/>').attr('src', url));
+
+      }
 
       function createUrl() {
         return Object.keys(api).map(function(key) { 


### PR DESCRIPTION
Tried in Chrome + Chrome Canary: went to the footer on http://api.html5please.com and clicked on the link to the original issue. Rather than being taken to it this happened instead:

http://addyosmani.com/gyazo/2502d9.png

I'm guessing GH doesn't like the exclusion of `http://` on that one. The Get WebGL and link and link to Alexis' twitter account don't seem to have the same issue.
