### PR TITLE
Fixes #24 - adding real-time preview of JSON output

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,10 @@
           </div>
          </div>
       </form>
+      <div class="preview">
+        <div class="response"></div>
+        <div class="placeholder"></div>
+      </div
       <div class="api-example">
         <h3>Use</h3>
         <a href="#" id="url" target="_blank"></a>

--- a/index.html
+++ b/index.html
@@ -134,7 +134,10 @@
         <img src="http://api.twitter.com/1/users/profile_image/aaronlayton?size=normal" alt="Aaron Layton">
         <b>Aaron</b> Layton 
       </a>
-
+      <a href="http://twitter.com/addyosmani">
+        <img src="http://api.twitter.com/1/users/profile_image/addyosmani?size=normal" alt="Addy Osmani">
+        <b>Addy</b> Osmani
+      </a>
 </div>
     <p> <a href="https://github.com/h5bp/caniuse/contributors">&amp; more</a> </p>
     <p>This project was inspired by <a href="//get.webgl.org/">get.webgl.org</a> and was initiated over at <a href="https://github.com/paulirish/lazyweb-requests/issues/39">github:paulirish/lazyweb-requests#39</a>. Much thanks to <a href="//twitter.com/fyrd">Alexis Deveria</a> for the generous sharing of <a href="http://caniuse.com/">caniuse</a> data. </p>

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -353,6 +353,20 @@ a {
 label[for='features'] {
   display: block; }
 
+.preview {
+  display:none;
+}
+
+.preview .response{
+  white-space: pre; 
+  word-break: break-word; 
+  min-height:50px;
+  max-height:300px;
+  overflow-y:scroll;
+  margin-bottom:10px;
+}
+
+
 .help {
   font-size: small;
   text-align: center;

--- a/site/css/style.scss
+++ b/site/css/style.scss
@@ -335,6 +335,20 @@ label[for='features'] {
   display: block;
 }
 
+.preview {
+  display:none;
+}
+
+.preview .response{
+  white-space: pre; 
+  word-break: break-word; 
+  min-height:50px;
+  max-height:300px;
+  overflow-y:scroll;
+  margin-bottom:10px;
+}
+
+
 .help {
   font-size: small;
   text-align: center;

--- a/site/js/script.js
+++ b/site/js/script.js
@@ -1,6 +1,7 @@
-      var $url = $('#url'),
+    var $url = $('#url'),
          $features = $('#features'),
          $options = $('#get-api').find('input'),
+         $preview = $('.preview'),
          $callback = '?callback=caniuse&';
 
 
@@ -98,10 +99,24 @@
          if(api.features !== '') {
            api.options = $callback + formattedOptions();
           
-           $url.text(createUrl());
+           $createdUrl = createUrl();
+           $url.text($createdUrl);
            $url.attr('href', $url.text());
+           getPreview($createdUrl);
          }
       };
+
+      window.caniuse = function(data) {   
+          $preview
+            .show()
+            .find('.response')
+            .html("<h3>Output Preview</h3>" + JSON.stringify(data, null, '\t'));
+      }
+
+ 
+      function getPreview( url ){
+        $('.placeholder').html( $('<script/>').attr('src', url));
+      }
 
       function createUrl() {
         return Object.keys(api).map(function(key) { 


### PR DESCRIPTION
Preview is hidden by default when the page loads. When a user selects a feature/set of features the preview displays with a simple pseudo-pretty-print. These changes have been applied to Divya's latest updates to only display JSON in the UI from a short while ago.

Screenshot: ![Screenshot](http://addyosmani.com/gyazo/e36a9c.png)
