### PR TITLE
Change the Modernizr.html5please features separator from ' ' to '+'.

### DIFF
--- a/modernizr.html5please.js
+++ b/modernizr.html5please.js
@@ -5,7 +5,7 @@
 
 
 //  Modernizr.html5please({
-//      features : 'opacity fontface postmessage regions',
+//      features : 'opacity+fontface+postmessage+regions',
 //      yep      : function(){ // tests all pass
 //          initApp();
 //      },
@@ -20,7 +20,7 @@
 Modernizr.html5please = function(opts){
     
     var passes = true;
-    var features = opts.features.split(' ');
+    var features = opts.features.split('+');
     var feat;
     for (var i = -1, len = features.length; ++i < len; ){
         feat = features[i];


### PR DESCRIPTION
The generated widget uses `+` to separate the list of features but `Modernizr.html5please` splits on a space, which causes errors.
