### PR TITLE
Add parenthesis around the shorthand if/else

### DIFF
--- a/modernizr.html5please.js
+++ b/modernizr.html5please.js
@@ -43,7 +43,7 @@ Modernizr.html5please = function(opts){
     var ref = document.getElementsByTagName('script')[0];
     var url = 'http://api.html5please.com/' + features.join('+') + 
               '.json?callback=Modernizr.html5please.cb' +
-              opts.options ? ('&' + opts.options) : '';
+              (opts.options ? ('&' + opts.options) : '');
     script.src = url;
     ref.parentNode.insertBefore(script, ref);
 

--- a/modernizr.html5please.js
+++ b/modernizr.html5please.js
@@ -20,7 +20,7 @@
 Modernizr.html5please = function(opts){
     
     var passes = true;
-    var features = opts.features.split(' ');
+    var features = opts.features.split('+');
     var feat;
     for (var i = -1, len = features.length; ++i < len; ){
         feat = features[i];
@@ -43,7 +43,7 @@ Modernizr.html5please = function(opts){
     var ref = document.getElementsByTagName('script')[0];
     var url = 'http://api.html5please.com/' + features.join('+') + 
               '.json?callback=Modernizr.html5please.cb' +
-              opts.options ? ('&' + opts.options) : '';
+              (opts.options ? ('&' + opts.options) : '');
     script.src = url;
     ref.parentNode.insertBefore(script, ref);
 

--- a/modernizr.html5please.js
+++ b/modernizr.html5please.js
@@ -20,7 +20,7 @@
 Modernizr.html5please = function(opts){
     
     var passes = true;
-    var features = opts.features.split('+');
+    var features = opts.features.split(' ');
     var feat;
     for (var i = -1, len = features.length; ++i < len; ){
         feat = features[i];

--- a/modernizr.html5please.js
+++ b/modernizr.html5please.js
@@ -43,7 +43,7 @@ Modernizr.html5please = function(opts){
     var ref = document.getElementsByTagName('script')[0];
     var url = 'http://api.html5please.com/' + features.join('+') + 
               '.json?callback=Modernizr.html5please.cb' +
-              (opts.options ? ('&' + opts.options) : '');
+              opts.options ? ('&' + opts.options) : '';
     script.src = url;
     ref.parentNode.insertBefore(script, ref);
 


### PR DESCRIPTION
On line 46 of modernizr.html5please.js, parenthesis should be added around the if/else statement. Without them, <code>opts.options</code> which is intended to be the if condition, will first get concatenated with its previous strings.
