### PR TITLE
Fixed sniffer regex to match internet explorer 11

### DIFF
--- a/agents.json
+++ b/agents.json
@@ -4,7 +4,7 @@
 		"prefix": "ms",
 		"type": "desktop",
 		"url": "http:\/\/www.microsoft.com\/windows\/internet-explorer\/",
-		"sniffer": "/(?:msie[\W\w]*?|Trident[\W\w]*rv\:)([\d\.]+)/i",
+		"sniffer": "/(?:msie[\\W\\w]*?|Trident[\\W\\w]*rv\\:)([\\d\\.]+)/i",
 		"currentVersion": "11"
 	},
 	"firefox": {

--- a/agents.json
+++ b/agents.json
@@ -4,8 +4,8 @@
 		"prefix": "ms",
 		"type": "desktop",
 		"url": "http:\/\/www.microsoft.com\/windows\/internet-explorer\/",
-		"sniffer": "/msie[\\W\\w]*?([\\d\\.]+)/i",
-		"currentVersion": "10"
+		"sniffer": "/(?:msie[\W\w]*?|Trident[\W\w]*rv\:)([\d\.]+)/i",
+		"currentVersion": "11"
 	},
 	"firefox": {
 		"name": "Firefox",


### PR DESCRIPTION
The guys from microsoft changed the user agent string for ie 11, to not match our used regular expressions. I added the „Trident“ part to fix this changes and match also to the new ua string pattern.
