### PR TITLE
Switched to Github API for avatars

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,38 +144,38 @@
     <div class="builders">
       <h3>Created By</h3>
       <a href="https://twitter.com/jon_neal">
-        <img src="https://twitter.com/api/users/profile_image/jon_neal?size=normal" alt="Jon Neal">
+        <img src="https://avatars.githubusercontent.com/u/188426?v=2&amp;s=100" alt="Jon Neal">
         <b>Jon</b> Neal
       </a>
       <a href="https://twitter.com/divya">
-        <img src="https://twitter.com/api/users/profile_image/divya?size=normal" alt="Divya Manian">
+        <img src="https://avatars.githubusercontent.com/u/74513?v=2&amp;s=100" alt="Divya Manian">
         <b>Divya</b> Manian
       </a>
     </div>
     <div class="builders">
       <h3>With</h3>
       <a href="https://twitter.com/paul_irish">
-        <img src="https://twitter.com/api/users/profile_image/paul_irish?size=normal" alt="Paul Irish">
+        <img src="https://avatars.githubusercontent.com/u/39191?v=2&amp;s=100" alt="Paul Irish">
         <b>Paul</b> Irish
       </a>
       <a href="https://twitter.com/fyrd">
-        <img src="https://twitter.com/api/users/profile_image/fyrd?size=normal" alt="Alexis Deveria">
+        <img src="https://avatars.githubusercontent.com/u/432336?v=2&amp;s=100" alt="Alexis Deveria">
         <b>Alexis</b> Deveria
       </a>
       <a href="https://twitter.com/aaronlayton">
-        <img src="https://twitter.com/api/users/profile_image/aaronlayton?size=normal" alt="Aaron Layton">
+        <img src="https://avatars.githubusercontent.com/u/694964?v=2&amp;s=100" alt="Aaron Layton">
         <b>Aaron</b> Layton
       </a>
       <a href="https://twitter.com/drublic">
-        <img src="https://twitter.com/api/users/profile_image/drublic?size=normal" alt="Hans Christian Reinl">
+        <img src="https://avatars.githubusercontent.com/u/502487?v=2&amp;s=100" alt="Hans Christian Reinl">
         <b>Hans Chr.</b> Reinl
       </a>
       <a href="https://twitter.com/addyosmani">
-        <img src="https://twitter.com/api/users/profile_image/addyosmani?size=normal" alt="Addy Osmani">
+        <img src="https://avatars.githubusercontent.com/u/110953?v=2&amp;s=100" alt="Addy Osmani">
         <b>Addy</b> Osmani
       </a>
       <a href="https://twitter.com/ourmaninjapan">
-        <img src="https://twitter.com/api/users/profile_image/ourmaninjapan?size=normal" alt="Daniel Davis">
+        <img src="https://avatars.githubusercontent.com/u/94173?v=2&amp;s=100" alt="Daniel Davis">
         <b>Daniel</b> Davis
       </a>
 </div>

--- a/site/css/style.css
+++ b/site/css/style.css
@@ -162,6 +162,9 @@ table {
   font-size: 16px;
   font-size: 1rem; }
 
+footer .builders img {
+  width: 50px; }
+
 .align-center, h1, h2, #about, #toc, #in-action, #in-action h3, #get-api, label[for='features'], #how-does-it-work h4, #reference, footer {
   text-align: center; }
 

--- a/site/css/style.scss
+++ b/site/css/style.scss
@@ -558,6 +558,10 @@ footer {
         margin-top: 0.5rem;
       }
     }
+
+    img {
+      width: 50px;
+    }
   } 
   p {
     margin-top: 0;


### PR DESCRIPTION
Right now, we use the twitter API to get the avatars in the footer. This method seems to be broken with the twitter API 1.1. 

![screenshot 2014-10-06 10 54 28](https://cloud.githubusercontent.com/assets/6025224/4523364/7c0b83ea-4d36-11e4-8bbb-ccb5580ba6bc.png)

First, I was planning to [use gravatar](https://github.com/h5bp/html5please/commit/011de6605c342509a59cd120df4d51534bbd6074) for this, but some guys don't have an account on gravatar.

I think it's probably the best idea to use the github API for this, just like h5bp.github.io is handling avatars.
